### PR TITLE
use s3browser caddy image

### DIFF
--- a/ansible/roles/downloads/defaults/main.yml
+++ b/ansible/roles/downloads/defaults/main.yml
@@ -1,4 +1,4 @@
-downloads_container: webhippie/caddy:latest
+downloads_container: techknowlogick/caddy-s3browser:latest
 downloads_domain: dl.gitea.io
 
 minio_container: webhippie/minio:latest

--- a/ansible/roles/downloads/templates/compose.j2
+++ b/ansible/roles/downloads/templates/compose.j2
@@ -14,21 +14,18 @@ services:
     image: ${DOWNLOADS_CONTAINER}
     restart: always
     environment:
-      - CADDY_WEBROOT=/var/lib/minio/releases
+      - S3_KEY=${MINIO_ACCESS}
+      - S3_SECRET=${MINIO_SECRET}
+      - S3_BUCKET=releases
+      - S3_ENDPOINT=storage.gitea.io
+      - S3_PROTO=https
+      - S3_HOST=storage.gitea.io
     networks:
       - traefik
     labels:
       - traefik.docker.network=traefik_general
-      - traefik.port=8080
+      - traefik.port=80
       - traefik.frontend.rule=Host:${DOWNLOADS_DOMAIN}
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-    volumes:
-      - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
-      - server:/var/lib/minio
 
   minio:
     image: ${MINIO_CONTAINER}

--- a/ansible/roles/downloads/templates/compose.j2
+++ b/ansible/roles/downloads/templates/compose.j2
@@ -20,12 +20,20 @@ services:
       - S3_ENDPOINT=storage.gitea.io
       - S3_PROTO=https
       - S3_HOST=storage.gitea.io
+      - S3_EXTRA=/releases/
     networks:
       - traefik
     labels:
       - traefik.docker.network=traefik_general
       - traefik.port=80
       - traefik.frontend.rule=Host:${DOWNLOADS_DOMAIN}
+    healthcheck:
+      test: ["CMD", "wget", "-O", "-", "http://localhost/"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
 
   minio:
     image: ${MINIO_CONTAINER}


### PR DESCRIPTION
Instead of having Caddy serve files from disk, this connects to Minio directly. This allows for in the future of potentially uploading binaries directly to DO spaces.

Note: Files on Minio may need to be set to public so they can be downloaded directly.